### PR TITLE
test: add CLI tests

### DIFF
--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,53 @@
+import { strictEqual } from 'node:assert'
+import { spawn } from 'node:child_process'
+import { describe, it } from 'mocha'
+import * as examples from './support/examples.js'
+
+function runCli (args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ['./bin/md-processor.js', ...args])
+    const stdout = []
+    const stderr = []
+
+    child.stdout.on('data', chunk => stdout.push(chunk))
+    child.stderr.on('data', chunk => stderr.push(chunk))
+
+    child.on('close', code => {
+      resolve({
+        stdout: Buffer.concat(stdout).toString(),
+        stderr: Buffer.concat(stderr).toString(),
+        code
+      })
+    })
+
+    child.on('error', reject)
+  })
+}
+
+describe('cli', () => {
+  it('should process all imports', async () => {
+    const { code, stdout } = await runCli(['./test/support/multi-imports.md'])
+
+    strictEqual(code, 0)
+    strictEqual(stdout, examples.multiImports.content)
+  })
+
+  it('should process deep imports', async () => {
+    const { code, stdout } = await runCli(['./test/support/import-deep.md'])
+
+    strictEqual(code, 0)
+    strictEqual(stdout, examples.importDeep.content)
+  })
+
+  it('should exit with an error when no input is given', async () => {
+    const { code } = await runCli([])
+
+    strictEqual(code, 1)
+  })
+
+  it('should exit with an error when the input file does not exist', async () => {
+    const { code } = await runCli(['./test/support/does-not-exist.md'])
+
+    strictEqual(code !== 0, true)
+  })
+})


### PR DESCRIPTION
- Adds `test/cli.test.js` which tests `bin/md-processor.js` as a black-box CLI by spawning it as a child process via `node:child_process.spawn`
- Covers happy paths (process imports, process deep imports) asserting both exit code 0 and exact stdout content
- Covers error paths (missing argument → exit 1 via Commander, non-existent file → exit non-zero)
- No new dependencies required